### PR TITLE
Fix backend secret key names

### DIFF
--- a/netflix-app/k8s/backend/deployment.yaml
+++ b/netflix-app/k8s/backend/deployment.yaml
@@ -23,12 +23,12 @@ spec:
           valueFrom:
             secretKeyRef:
               name: tmdb-secrets
-              key: TMDB_API_KEY
+              key: api-key
         - name: TMDB_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:
               name: tmdb-secrets
-              key: TMDB_ACCESS_TOKEN
+              key: access-token
         resources:
           limits:
             cpu: "0.5"


### PR DESCRIPTION
## Summary
- fix secret key names for TMDB in backend deployment

## Testing
- `npm test` *(fails: missing script)*
- `npm test --silent` in frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcce360388330a8d444736cda555f