### PR TITLE
Add Jest and health endpoint test

### DIFF
--- a/netflix-app/backend/package.json
+++ b/netflix-app/backend/package.json
@@ -5,7 +5,8 @@
   "main": "src/app.js",
   "scripts": {
     "start": "node src/app.js",
-    "dev": "nodemon src/app.js"
+    "dev": "nodemon src/app.js",
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.18.2",
@@ -14,6 +15,7 @@
     "dotenv": "^16.3.1"
   },
   "devDependencies": {
-    "nodemon": "^3.0.2"
+    "nodemon": "^3.0.2",
+    "jest": "^29.6.4"
   }
-} 
+}

--- a/netflix-app/backend/test/health.test.js
+++ b/netflix-app/backend/test/health.test.js
@@ -1,0 +1,19 @@
+const { exec } = require('child_process');
+const axios = require('axios');
+
+let server;
+
+beforeAll(done => {
+  server = exec('node src/app.js', () => {});
+  setTimeout(done, 1000); // give the server time to start
+});
+
+afterAll(() => {
+  if (server) server.kill();
+});
+
+test('GET /health returns healthy', async () => {
+  const res = await axios.get('http://localhost:8080/health');
+  expect(res.status).toBe(200);
+  expect(res.data).toEqual({ status: 'healthy' });
+});


### PR DESCRIPTION
## Summary
- add Jest as dev dependency
- add test script
- create `health.test.js` to verify `/health` endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fccfc62788330b9c8ad7247c704d2